### PR TITLE
Fix for Debian 9/stretch moved to archive.debian.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:9.12-slim
+FROM debian:9.5-slim
 
 LABEL "com.github.actions.name"="Post Typetalk messages"
 LABEL "com.github.actions.description"="Post Typetalk messages from your own bot"
 LABEL "com.github.actions.icon"="message-square"
 LABEL "com.github.actions.color"="gray-dark"
 
-LABEL version="0.9.0"
+LABEL version="0.9.1"
 LABEL repository="https://github.com/shomatan/typetalk-action"
 LABEL homepage="https://github.com/shomatan/typetalk-action"
 LABEL maintainer="Shoma Nishitateno <shoma416@gmail.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.5-slim
+FROM debian:10.13-slim
 
 LABEL "com.github.actions.name"="Post Typetalk messages"
 LABEL "com.github.actions.description"="Post Typetalk messages from your own bot"


### PR DESCRIPTION

This pull request updates the dependencies on Debian versions in response to Fix for Debian 9/stretch moved to archive.debian.org.

> Debian 9/stretch moved to archive.debian.org
> (2023-04-23 or later).
[Debian 9/stretch moved to archive.debian.org](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html)


## Tests

Test on Github actions.

### before

```
Build shomatan/typetalk-action@master
....

E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
```

[Create run.yml · ymmtyuhei/run-typetalk-action@218bad0](https://github.com/ymmtyuhei/run-typetalk-action/actions/runs/4784128750/jobs/8505222501#step:2:97)


### after 

[Update run.yml · ymmtyuhei/run-typetalk-action@17ac0b9](https://github.com/ymmtyuhei/run-typetalk-action/actions/runs/4784172561/jobs/8505647112)
